### PR TITLE
READMEをpnpmに移行

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,13 @@
 First, install the dependencies:
 
 ```bash
-npm install
-# or
-yarn install
+pnpm install
 ```
 
 Then, run the development server:
 
 ```bash
-npm run dev
-# or
-yarn dev
+pnpm dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.


### PR DESCRIPTION
## Summary

- `npm install` / `yarn install` を `pnpm install` に変更
- `npm run dev` / `yarn dev` を `pnpm dev` に変更

## Background

プロジェクトはすでにnpmからpnpmへ移行済み（#198）だが、READMEのコマンド例が古いままだったため更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)