### PR TITLE
Add Dependabot configuration (security updates only, 7-day cooldown)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

- `.github/dependabot.yml` を新規追加
- `open-pull-requests-limit: 0` でバージョンアップデートPRを無効化し、セキュリティアップデートのみ有効化
- `cooldown.default-days: 7` で新バージョンリリースから7日間待機してからPRを作成（サプライチェーン攻撃対策）

## Reviewer notes

- セキュリティアップデートはGitHubリポジトリ設定の **Security > Dependabot security updates** で有効化が必要（デフォルト有効のはず）
- `cooldown` はバージョンアップデートにのみ適用されるオプションのため、セキュリティアップデートへの影響は限定的な可能性あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)