### PR TITLE
デザインのブラッシュアップ(アイコン統一・日本語フォント・モバイルカード表示)

### DIFF
--- a/components/BroadcastEmbed.tsx
+++ b/components/BroadcastEmbed.tsx
@@ -60,10 +60,10 @@ const BroadcastEmbed: React.FC<BroadcastEmbedProps> = ({
 
   // どちらも利用できない場合
   return (
-    <div className="w-full flex justify-center my-4 p-4 border border-gray-200 rounded-lg bg-gray-50">
-      <div className="text-center text-gray-600">
-        <p className="mb-2">🎵 配信が利用できません</p>
-        <p className="text-sm">YouTube・Spotify版ともに現在利用できません</p>
+    <div className="w-full flex justify-center my-4 p-4 border border-surface-200 rounded-xl bg-surface-50">
+      <div className="text-center">
+        <p className="mb-1 text-sm font-medium text-text-secondary">配信が利用できません</p>
+        <p className="text-xs text-text-muted m-0">YouTube・Spotify版ともに現在利用できません</p>
       </div>
     </div>
   );

--- a/components/BroadcastSummaryModal.tsx
+++ b/components/BroadcastSummaryModal.tsx
@@ -36,12 +36,12 @@ export default function BroadcastSummaryModal({
 
         <div className="p-6 max-md:p-4">
           <div className="mb-8 last:mb-0 max-md:mb-6">
-            <h3 className="m-0 mb-3 text-sm font-semibold text-primary-600 uppercase tracking-wide max-md:text-xs">概要</h3>
+            <h3 className="m-0 mb-3 text-sm font-semibold text-primary-600 max-md:text-xs">概要</h3>
             <p className="m-0 text-sm leading-relaxed text-text-primary bg-primary-50/50 p-4 rounded-xl border-l-3 border-l-primary-400 max-md:p-3">{summary.overview}</p>
           </div>
 
           <div className="mb-8 last:mb-0 max-md:mb-6">
-            <h3 className="m-0 mb-3 text-sm font-semibold text-emerald-600 uppercase tracking-wide max-md:text-xs">事実や出来事</h3>
+            <h3 className="m-0 mb-3 text-sm font-semibold text-emerald-600 max-md:text-xs">事実や出来事</h3>
             <div className="flex flex-col gap-2">
               {summary.facts.map((fact, index) => (
                 <div key={index} className="p-3.5 bg-emerald-50/50 rounded-xl border-l-3 border-l-emerald-400 text-sm leading-relaxed text-text-primary max-md:p-2.5 max-md:text-xs">{fact}</div>
@@ -50,7 +50,7 @@ export default function BroadcastSummaryModal({
           </div>
 
           <div className="mb-8 last:mb-0 max-md:mb-6">
-            <h3 className="m-0 mb-3 text-sm font-semibold text-amber-600 uppercase tracking-wide max-md:text-xs">学び・教訓・法則</h3>
+            <h3 className="m-0 mb-3 text-sm font-semibold text-amber-600 max-md:text-xs">学び・教訓・法則</h3>
             <div className="flex flex-col gap-2">
               {summary.lessons.map((lesson, index) => (
                 <div key={index} className="p-3.5 bg-amber-50/50 rounded-xl border-l-3 border-l-amber-400 text-sm leading-relaxed text-text-primary max-md:p-2.5 max-md:text-xs">{lesson}</div>

--- a/components/BroadcastsContent.tsx
+++ b/components/BroadcastsContent.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import BroadcastEmbed from './BroadcastEmbed';
 import BroadcastSummaryModal from './BroadcastSummaryModal';
 import SummaryButton from './SummaryButton';
+import { PlayIcon, StopIcon, LightbulbIcon, ChevronRightIcon } from './icons';
 import { PastBroadcast } from '../types/broadcast';
 
 interface BroadcastsContentProps {
@@ -13,6 +14,11 @@ interface BroadcastsContentProps {
   embedType: 'youtube' | 'spotify';
 }
 
+type SortColumn = 'date' | 'title' | 'duration';
+
+const thClass = "px-4 py-3 text-left text-xs font-semibold text-text-muted bg-surface-50 border-b border-surface-200 whitespace-nowrap";
+const thSortableClass = `${thClass} cursor-pointer select-none hover:text-primary-600 transition-colors`;
+
 const BroadcastsContent = React.memo(({
   pastBroadcasts,
   isLoadingBroadcasts,
@@ -22,14 +28,14 @@ const BroadcastsContent = React.memo(({
   embedType
 }: BroadcastsContentProps) => {
   const formatDuration = useCallback((seconds: number | undefined): string => {
-    if (!seconds) return '\u2014';
+    if (!seconds) return '—';
     const minutes = Math.floor(seconds / 60);
     const remainingSeconds = seconds % 60;
     return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
   }, []);
 
   const formatDurationInHours = useCallback((seconds: number | undefined): string => {
-    if (!seconds) return '\u2014';
+    if (!seconds) return '—';
     const hours = Math.floor(seconds / 3600);
     const minutes = Math.floor((seconds % 3600) / 60);
     if (hours > 0) {
@@ -40,13 +46,13 @@ const BroadcastsContent = React.memo(({
   }, []);
 
   const formatDate = useCallback((date: string | undefined): string => {
-    if (!date) return '\u2014';
+    if (!date) return '—';
     return date;
   }, []);
 
   const [expandedSeries, setExpandedSeries] = useState<Record<string, boolean>>({});
   const [groupDisplayMode, setGroupDisplayMode] = useState<boolean>(true);
-  const [sortColumn, setSortColumn] = useState<'date' | 'title' | 'duration'>('date');
+  const [sortColumn, setSortColumn] = useState<SortColumn>('date');
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
   const [summaryModalOpen, setSummaryModalOpen] = useState<boolean>(false);
   const [selectedBroadcastForSummary, setSelectedBroadcastForSummary] = useState<PastBroadcast | null>(null);
@@ -143,7 +149,7 @@ const BroadcastsContent = React.memo(({
     setExpandedSeries(allCollapsed);
   }, [broadcastsBySeries]);
 
-  const handleSort = useCallback((column: 'date' | 'title' | 'duration') => {
+  const handleSort = useCallback((column: SortColumn) => {
     if (sortColumn === column) {
       setSortDirection(prev => prev === 'asc' ? 'desc' : 'asc');
     } else {
@@ -157,12 +163,12 @@ const BroadcastsContent = React.memo(({
   const getSeriesAccent = useCallback((series: string) => {
     const index = seriesList.indexOf(series);
     const accents = [
-      { bg: 'bg-primary-50', border: 'border-l-primary-400', headerBg: 'bg-primary-50/60' },
-      { bg: 'bg-emerald-50', border: 'border-l-emerald-400', headerBg: 'bg-emerald-50/60' },
-      { bg: 'bg-amber-50', border: 'border-l-amber-400', headerBg: 'bg-amber-50/60' },
-      { bg: 'bg-rose-50', border: 'border-l-rose-400', headerBg: 'bg-rose-50/60' },
-      { bg: 'bg-cyan-50', border: 'border-l-cyan-400', headerBg: 'bg-cyan-50/60' },
-      { bg: 'bg-violet-50', border: 'border-l-violet-400', headerBg: 'bg-violet-50/60' },
+      { bar: 'bg-primary-400', headerBg: 'bg-primary-50/60' },
+      { bar: 'bg-emerald-400', headerBg: 'bg-emerald-50/60' },
+      { bar: 'bg-amber-400', headerBg: 'bg-amber-50/60' },
+      { bar: 'bg-rose-400', headerBg: 'bg-rose-50/60' },
+      { bar: 'bg-cyan-400', headerBg: 'bg-cyan-50/60' },
+      { bar: 'bg-violet-400', headerBg: 'bg-violet-50/60' },
     ];
     return accents[index % accents.length];
   }, [seriesList]);
@@ -176,6 +182,26 @@ const BroadcastsContent = React.memo(({
     setSummaryModalOpen(false);
     setSelectedBroadcastForSummary(null);
   }, []);
+
+  const getHypothesesQuery = useCallback((broadcast: PastBroadcast) => {
+    return groupDisplayMode
+      ? `/?tab=hypotheses&series=${encodeURIComponent(broadcast.series && broadcast.series.trim() ? broadcast.series.trim() : 'その他')}`
+      : `/?tab=hypotheses&episodeId=${broadcast.id}`;
+  }, [groupDisplayMode]);
+
+  const renderActions = useCallback((broadcast: PastBroadcast) => (
+    <>
+      <button type="button" onClick={() => toggleEmbedVisibility(broadcast.id)} className="btn-icon" aria-label={visibleEmbeds.has(broadcast.id) ? '再生を閉じる' : '再生する'}>
+        {visibleEmbeds.has(broadcast.id) ? <StopIcon /> : <PlayIcon />}
+      </button>
+      <button type="button" onClick={() => router.push(getHypothesesQuery(broadcast))} className="btn-icon" aria-label="仮説を見る">
+        <LightbulbIcon />
+      </button>
+      <SummaryButton broadcast={broadcast} onOpenSummary={openSummaryModal} />
+    </>
+  ), [toggleEmbedVisibility, visibleEmbeds, router, getHypothesesQuery, openSummaryModal]);
+
+  const sortLabels: Record<SortColumn, string> = { date: '日付', title: 'タイトル', duration: '再生時間' };
 
   return (
     <>
@@ -212,7 +238,7 @@ const BroadcastsContent = React.memo(({
               </button>
             </div>
 
-            {groupDisplayMode && (
+            {groupDisplayMode ? (
               <div className="flex items-center gap-2 max-md:justify-center">
                 <button onClick={expandAllSeries} className="btn-secondary text-xs px-3 py-1.5">
                   すべて展開
@@ -221,32 +247,54 @@ const BroadcastsContent = React.memo(({
                   すべて閉じる
                 </button>
               </div>
+            ) : (
+              <div className="hidden max-md:flex items-center justify-center gap-2">
+                <label htmlFor="broadcast-sort" className="text-sm font-medium text-text-secondary">並び順:</label>
+                <select
+                  id="broadcast-sort"
+                  value={sortColumn}
+                  onChange={(e) => setSortColumn(e.target.value as SortColumn)}
+                  className="px-3 py-1.5 border border-surface-200 rounded-lg bg-surface-50 text-text-primary text-sm cursor-pointer focus:outline-none focus:border-primary-400"
+                >
+                  {(Object.keys(sortLabels) as SortColumn[]).map(column => (
+                    <option key={column} value={column}>{sortLabels[column]}</option>
+                  ))}
+                </select>
+                <button
+                  onClick={() => setSortDirection(prev => prev === 'asc' ? 'desc' : 'asc')}
+                  className="btn-secondary text-xs px-3 py-1.5"
+                  aria-label={sortDirection === 'asc' ? '昇順' : '降順'}
+                >
+                  {sortDirection === 'asc' ? '昇順 ↑' : '降順 ↓'}
+                </button>
+              </div>
             )}
           </div>
 
-          <div className="w-full card-modern overflow-hidden">
+          {/* Desktop: table view */}
+          <div className="w-full card-modern overflow-hidden max-md:hidden">
             <table className="w-full border-separate border-spacing-0">
               <thead>
                 <tr>
                   {groupDisplayMode ? (
                     <>
-                      <th className="px-4 py-3 text-left text-xs font-semibold text-text-muted uppercase tracking-wider bg-surface-50 border-b border-surface-200 first:rounded-tl-2xl whitespace-nowrap">日付</th>
-                      <th className="px-4 py-3 text-left text-xs font-semibold text-text-muted uppercase tracking-wider bg-surface-50 border-b border-surface-200 whitespace-nowrap">タイトル</th>
-                      <th className="px-4 py-3 text-left text-xs font-semibold text-text-muted uppercase tracking-wider bg-surface-50 border-b border-surface-200 whitespace-nowrap">再生時間</th>
-                      <th className="px-4 py-3 text-left text-xs font-semibold text-text-muted uppercase tracking-wider bg-surface-50 border-b border-surface-200 last:rounded-tr-2xl whitespace-nowrap">リンク</th>
+                      <th className={`${thClass} first:rounded-tl-2xl`}>日付</th>
+                      <th className={thClass}>タイトル</th>
+                      <th className={thClass}>再生時間</th>
+                      <th className={`${thClass} last:rounded-tr-2xl`}>リンク</th>
                     </>
                   ) : (
                     <>
-                      <th className="cursor-pointer select-none px-4 py-3 text-left text-xs font-semibold text-text-muted uppercase tracking-wider bg-surface-50 border-b border-surface-200 first:rounded-tl-2xl whitespace-nowrap hover:text-primary-600 transition-colors" onClick={() => handleSort('date')}>
-                        日付 {sortColumn === 'date' && (sortDirection === 'asc' ? '\u2191' : '\u2193')}
+                      <th className={`${thSortableClass} first:rounded-tl-2xl`} onClick={() => handleSort('date')}>
+                        日付 {sortColumn === 'date' && (sortDirection === 'asc' ? '↑' : '↓')}
                       </th>
-                      <th className="cursor-pointer select-none px-4 py-3 text-left text-xs font-semibold text-text-muted uppercase tracking-wider bg-surface-50 border-b border-surface-200 whitespace-nowrap hover:text-primary-600 transition-colors" onClick={() => handleSort('title')}>
-                        タイトル {sortColumn === 'title' && (sortDirection === 'asc' ? '\u2191' : '\u2193')}
+                      <th className={thSortableClass} onClick={() => handleSort('title')}>
+                        タイトル {sortColumn === 'title' && (sortDirection === 'asc' ? '↑' : '↓')}
                       </th>
-                      <th className="cursor-pointer select-none px-4 py-3 text-left text-xs font-semibold text-text-muted uppercase tracking-wider bg-surface-50 border-b border-surface-200 whitespace-nowrap hover:text-primary-600 transition-colors" onClick={() => handleSort('duration')}>
-                        再生時間 {sortColumn === 'duration' && (sortDirection === 'asc' ? '\u2191' : '\u2193')}
+                      <th className={thSortableClass} onClick={() => handleSort('duration')}>
+                        再生時間 {sortColumn === 'duration' && (sortDirection === 'asc' ? '↑' : '↓')}
                       </th>
-                      <th className="px-4 py-3 text-left text-xs font-semibold text-text-muted uppercase tracking-wider bg-surface-50 border-b border-surface-200 last:rounded-tr-2xl whitespace-nowrap">リンク</th>
+                      <th className={`${thClass} last:rounded-tr-2xl`}>リンク</th>
                     </>
                   )}
                 </tr>
@@ -265,9 +313,9 @@ const BroadcastsContent = React.memo(({
                             <td colSpan={4} className="px-4 py-3 border-b border-surface-200">
                               <div className="flex items-center justify-between">
                                 <div className="flex items-center gap-2">
-                                  <span className={`w-1 h-8 rounded-full ${accent.border.replace('border-l-', 'bg-')}`}></span>
-                                  <span className="text-xs text-text-muted w-5 text-center transition-transform duration-200" style={{ transform: expandedSeries[series] ? 'rotate(90deg)' : 'rotate(0deg)' }}>
-                                    ▶
+                                  <span className={`w-1 h-8 rounded-full ${accent.bar}`}></span>
+                                  <span className="text-text-muted transition-transform duration-200" style={{ transform: expandedSeries[series] ? 'rotate(90deg)' : 'rotate(0deg)' }}>
+                                    <ChevronRightIcon />
                                   </span>
                                   <span className="font-semibold text-text-primary">{series}</span>
                                   <span className="text-xs text-text-muted bg-surface-100 px-2 py-0.5 rounded-full">{broadcasts.length}</span>
@@ -283,16 +331,10 @@ const BroadcastsContent = React.memo(({
                               <tr className="hover:bg-primary-50/30 transition-colors duration-150 group">
                                 <td className="px-4 py-3 text-sm text-text-secondary border-b border-surface-100 whitespace-nowrap">{formatDate(broadcast.date)}</td>
                                 <td className="px-4 py-3 text-sm text-text-primary border-b border-surface-100 font-medium">{broadcast.title}</td>
-                                <td className="px-4 py-3 text-sm text-text-secondary border-b border-surface-100 whitespace-nowrap font-mono text-xs">{formatDuration(broadcast.duration)}</td>
+                                <td className="px-4 py-3 text-text-secondary border-b border-surface-100 whitespace-nowrap font-mono text-xs">{formatDuration(broadcast.duration)}</td>
                                 <td className="px-4 py-3 border-b border-surface-100 whitespace-nowrap">
                                   <div className="flex items-center gap-1.5 opacity-70 group-hover:opacity-100 transition-opacity">
-                                    <button type="button" onClick={() => toggleEmbedVisibility(broadcast.id)} className="btn-icon" aria-label={visibleEmbeds.has(broadcast.id) ? '非表示' : '再生'}>
-                                      {visibleEmbeds.has(broadcast.id) ? '\u23F9\uFE0F' : '\u25B6\uFE0F'}
-                                    </button>
-                                    <button type="button" onClick={() => router.push(`/?tab=hypotheses&series=${encodeURIComponent(broadcast.series && broadcast.series.trim() ? broadcast.series.trim() : 'その他')}`)} className="btn-icon" aria-label="仮説を見る">
-                                      💬
-                                    </button>
-                                    <SummaryButton broadcast={broadcast} onOpenSummary={openSummaryModal} />
+                                    {renderActions(broadcast)}
                                   </div>
                                 </td>
                               </tr>
@@ -321,16 +363,10 @@ const BroadcastsContent = React.memo(({
                             </span>
                           </div>
                         </td>
-                        <td className="px-4 py-3 text-sm text-text-secondary border-b border-surface-100 whitespace-nowrap font-mono text-xs">{formatDuration(broadcast.duration)}</td>
+                        <td className="px-4 py-3 text-text-secondary border-b border-surface-100 whitespace-nowrap font-mono text-xs">{formatDuration(broadcast.duration)}</td>
                         <td className="px-4 py-3 border-b border-surface-100 whitespace-nowrap">
                           <div className="flex items-center gap-1.5 opacity-70 group-hover:opacity-100 transition-opacity">
-                            <button type="button" onClick={() => toggleEmbedVisibility(broadcast.id)} className="btn-icon" aria-label={visibleEmbeds.has(broadcast.id) ? '非表示' : '再生'}>
-                              {visibleEmbeds.has(broadcast.id) ? '\u23F9\uFE0F' : '\u25B6\uFE0F'}
-                            </button>
-                            <button type="button" onClick={() => router.push(`/?tab=hypotheses&episodeId=${broadcast.id}`)} className="btn-icon" aria-label="仮説を見る">
-                              💬
-                            </button>
-                            <SummaryButton broadcast={broadcast} onOpenSummary={openSummaryModal} />
+                            {renderActions(broadcast)}
                           </div>
                         </td>
                       </tr>
@@ -346,6 +382,89 @@ const BroadcastsContent = React.memo(({
                 )}
               </tbody>
             </table>
+          </div>
+
+          {/* Mobile: card view */}
+          <div className="hidden max-md:flex w-full flex-col gap-3">
+            {groupDisplayMode ? (
+              sortSeriesByNumber(Object.entries(broadcastsBySeries))
+                .map(([series, broadcasts]) => {
+                  const accent = getSeriesAccent(series);
+                  return (
+                    <div key={series} className="card-modern overflow-hidden">
+                      <button
+                        type="button"
+                        onClick={() => toggleSeries(series)}
+                        className={`w-full flex items-center justify-between gap-2 px-4 py-3 text-left border-none cursor-pointer ${accent.headerBg}`}
+                      >
+                        <div className="flex items-center gap-2 min-w-0">
+                          <span className={`w-1 h-8 rounded-full flex-shrink-0 ${accent.bar}`}></span>
+                          <span className="text-text-muted flex-shrink-0 transition-transform duration-200" style={{ transform: expandedSeries[series] ? 'rotate(90deg)' : 'rotate(0deg)' }}>
+                            <ChevronRightIcon />
+                          </span>
+                          <span className="font-semibold text-sm text-text-primary truncate">{series}</span>
+                          <span className="text-xs text-text-muted bg-surface-100 px-2 py-0.5 rounded-full flex-shrink-0">{broadcasts.length}</span>
+                        </div>
+                        <span className="text-xs text-text-muted font-medium whitespace-nowrap flex-shrink-0">
+                          {calculateSeresTotalDuration(broadcasts)}
+                        </span>
+                      </button>
+                      {expandedSeries[series] && (
+                        <div className="flex flex-col divide-y divide-surface-100 border-t border-surface-100">
+                          {broadcasts.map((broadcast) => (
+                            <div key={broadcast.id} className="px-4 py-3">
+                              <div className="flex items-start justify-between gap-3">
+                                <div className="min-w-0 flex-1">
+                                  <p className="m-0 text-sm font-medium text-text-primary leading-snug">{broadcast.title}</p>
+                                  <p className="m-0 mt-1 text-xs text-text-muted">
+                                    {formatDate(broadcast.date)}
+                                    <span className="mx-1.5">·</span>
+                                    {formatDuration(broadcast.duration)}
+                                  </p>
+                                </div>
+                                <div className="flex items-center gap-1.5 flex-shrink-0">
+                                  {renderActions(broadcast)}
+                                </div>
+                              </div>
+                              {visibleEmbeds.has(broadcast.id) && (
+                                <div className="mt-3">
+                                  <BroadcastEmbed broadcast={broadcast} embedType={embedType} height={152} />
+                                </div>
+                              )}
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })
+            ) : (
+              sortedBroadcasts.map((broadcast) => (
+                <div key={broadcast.id} className="card-modern p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <p className="m-0 text-sm font-medium text-text-primary leading-snug">{broadcast.title}</p>
+                      <p className="m-0 mt-1 text-xs text-text-muted">
+                        {broadcast.series && broadcast.series.trim() ? broadcast.series.trim() : '999. その他'}
+                      </p>
+                      <p className="m-0 mt-1 text-xs text-text-muted">
+                        {formatDate(broadcast.date)}
+                        <span className="mx-1.5">·</span>
+                        {formatDuration(broadcast.duration)}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-1.5 flex-shrink-0">
+                      {renderActions(broadcast)}
+                    </div>
+                  </div>
+                  {visibleEmbeds.has(broadcast.id) && (
+                    <div className="mt-3 pt-3 border-t border-surface-100">
+                      <BroadcastEmbed broadcast={broadcast} embedType={embedType} height={152} />
+                    </div>
+                  )}
+                </div>
+              ))
+            )}
           </div>
         </>
       )}

--- a/components/HypothesesSection.tsx
+++ b/components/HypothesesSection.tsx
@@ -24,7 +24,15 @@ export default function HypothesesSection({ pastBroadcasts, selectedSeries, sele
   const [hypotheses, setHypotheses] = useState<Hypothesis[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [dropdownSeries, setDropdownSeries] = useState<string | undefined>(selectedSeries);
+  const [isNarrowViewport, setIsNarrowViewport] = useState<boolean>(false);
   const hypothesesListRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const checkViewport = () => setIsNarrowViewport(window.innerWidth < 768);
+    checkViewport();
+    window.addEventListener('resize', checkViewport);
+    return () => window.removeEventListener('resize', checkViewport);
+  }, []);
 
   const router = useRouter();
 
@@ -211,7 +219,7 @@ export default function HypothesesSection({ pastBroadcasts, selectedSeries, sele
           <div className="flex gap-6 w-full max-lg:flex-col max-lg:gap-4">
             {/* Left side: Graph */}
             <div className="flex-1 min-w-[600px] max-lg:flex-none max-lg:min-w-0">
-              <div className="w-full h-[600px] rounded-xl overflow-hidden bg-white">
+              <div className="w-full h-[600px] rounded-xl overflow-hidden bg-white max-md:h-[480px]">
                 <Plot
                   data={getUniqueTopics().map(topic => {
                     const topicHypotheses = filteredHypotheses.filter(h => h.topic === topic);
@@ -258,7 +266,7 @@ export default function HypothesesSection({ pastBroadcasts, selectedSeries, sele
                   })}
                   layout={{
                     width: undefined,
-                    height: 600,
+                    height: isNarrowViewport ? 480 : 600,
                     xaxis: {
                       autorange: true,
                       showgrid: true,
@@ -280,7 +288,14 @@ export default function HypothesesSection({ pastBroadcasts, selectedSeries, sele
                     plot_bgcolor: '#fafbfc',
                     paper_bgcolor: 'white',
                     margin: { l: 40, r: 20, t: 20, b: 20 },
-                    legend: {
+                    legend: isNarrowViewport ? {
+                      orientation: 'h',
+                      x: 0,
+                      y: -0.05,
+                      yanchor: 'top',
+                      bgcolor: 'rgba(255,255,255,0.9)',
+                      font: { size: 10, color: '#475569' }
+                    } : {
                       orientation: 'v',
                       x: 1.02,
                       y: 1,
@@ -362,27 +377,24 @@ export default function HypothesesSection({ pastBroadcasts, selectedSeries, sele
                       <p className="m-0 text-xs text-text-muted text-right">by {hypothesis.proposer}</p>
 
                       {/* Feedback buttons */}
-                      <div className="flex gap-1.5 mt-2.5 pt-2.5 border-t border-surface-100">
+                      <div className="flex flex-wrap gap-1.5 mt-2.5 pt-2.5 border-t border-surface-100">
                         <button
-                          className="px-2.5 py-1 rounded-lg bg-surface-50 text-text-secondary text-xs font-medium cursor-pointer transition-all duration-200 border border-surface-200 hover:bg-primary-50 hover:text-primary-600 hover:border-primary-200 active:scale-95"
+                          className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg bg-surface-50 text-text-secondary text-xs font-medium cursor-pointer transition-all duration-200 border border-surface-200 hover:bg-primary-50 hover:text-primary-600 hover:border-primary-200 active:scale-95"
                           onClick={(e) => { e.stopPropagation(); handleFeedback('interesting', hypothesis); }}
-                          title="興味深い"
                         >
-                          🤔
+                          <span aria-hidden="true">🤔</span> 興味深い
                         </button>
                         <button
-                          className="px-2.5 py-1 rounded-lg bg-surface-50 text-text-secondary text-xs font-medium cursor-pointer transition-all duration-200 border border-surface-200 hover:bg-amber-50 hover:text-amber-600 hover:border-amber-200 active:scale-95"
+                          className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg bg-surface-50 text-text-secondary text-xs font-medium cursor-pointer transition-all duration-200 border border-surface-200 hover:bg-amber-50 hover:text-amber-600 hover:border-amber-200 active:scale-95"
                           onClick={(e) => { e.stopPropagation(); handleFeedback('groundbreaking', hypothesis); }}
-                          title="画期的"
                         >
-                          ✨
+                          <span aria-hidden="true">✨</span> 画期的
                         </button>
                         <button
-                          className="px-2.5 py-1 rounded-lg bg-surface-50 text-text-secondary text-xs font-medium cursor-pointer transition-all duration-200 border border-surface-200 hover:bg-emerald-50 hover:text-emerald-600 hover:border-emerald-200 active:scale-95"
+                          className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg bg-surface-50 text-text-secondary text-xs font-medium cursor-pointer transition-all duration-200 border border-surface-200 hover:bg-emerald-50 hover:text-emerald-600 hover:border-emerald-200 active:scale-95"
                           onClick={(e) => { e.stopPropagation(); handleFeedback('worth-testing', hypothesis); }}
-                          title="検証したい"
                         >
-                          🎯
+                          <span aria-hidden="true">🎯</span> 検証したい
                         </button>
                       </div>
                     </div>

--- a/components/PopularBroadcastsContent.tsx
+++ b/components/PopularBroadcastsContent.tsx
@@ -3,6 +3,7 @@ import { NextRouter } from 'next/router';
 import BroadcastEmbed from './BroadcastEmbed';
 import BroadcastSummaryModal from './BroadcastSummaryModal';
 import SummaryButton from './SummaryButton';
+import { PlayIcon, StopIcon, LightbulbIcon } from './icons';
 import { PopularBroadcast } from '../types/broadcast';
 
 interface PopularBroadcastsContentProps {
@@ -12,6 +13,8 @@ interface PopularBroadcastsContentProps {
   embedType: 'youtube' | 'spotify';
 }
 
+type SortColumn = 'viewCount' | 'hypothesisCount' | 'likeCount' | 'title' | 'date';
+
 export default function PopularBroadcastsContent({
   visibleEmbeds,
   toggleEmbedVisibility,
@@ -20,7 +23,7 @@ export default function PopularBroadcastsContent({
 }: PopularBroadcastsContentProps) {
   const [popularBroadcasts, setPopularBroadcasts] = useState<PopularBroadcast[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [sortColumn, setSortColumn] = useState<'viewCount' | 'hypothesisCount' | 'likeCount' | 'title' | 'date'>('viewCount');
+  const [sortColumn, setSortColumn] = useState<SortColumn>('viewCount');
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
   const [summaryModalOpen, setSummaryModalOpen] = useState<boolean>(false);
   const [selectedBroadcastForSummary, setSelectedBroadcastForSummary] = useState<PopularBroadcast | null>(null);
@@ -64,7 +67,7 @@ export default function PopularBroadcastsContent({
     return sorted;
   }, [popularBroadcasts, sortColumn, sortDirection]);
 
-  const handleSort = useCallback((column: typeof sortColumn) => {
+  const handleSort = useCallback((column: SortColumn) => {
     if (sortColumn === column) {
       setSortDirection(prev => prev === 'asc' ? 'desc' : 'asc');
     } else {
@@ -83,6 +86,18 @@ export default function PopularBroadcastsContent({
     setSelectedBroadcastForSummary(null);
   }, []);
 
+  const renderActions = useCallback((broadcast: PopularBroadcast) => (
+    <>
+      <button type="button" onClick={() => toggleEmbedVisibility(broadcast.id)} className="btn-icon" aria-label={visibleEmbeds.has(broadcast.id) ? '再生を閉じる' : '再生する'}>
+        {visibleEmbeds.has(broadcast.id) ? <StopIcon /> : <PlayIcon />}
+      </button>
+      <button type="button" onClick={() => router.push(`/?tab=hypotheses&series=${encodeURIComponent(broadcast.series && broadcast.series.trim() ? broadcast.series.trim() : 'その他')}`)} className="btn-icon" aria-label="仮説を見る">
+        <LightbulbIcon />
+      </button>
+      <SummaryButton broadcast={broadcast} onOpenSummary={openSummaryModal} />
+    </>
+  ), [toggleEmbedVisibility, visibleEmbeds, router, openSummaryModal]);
+
   if (isLoading) {
     return (
       <div className="flex flex-col items-center gap-4 my-16">
@@ -92,30 +107,60 @@ export default function PopularBroadcastsContent({
     );
   }
 
-  const thClass = "cursor-pointer select-none px-4 py-3 text-left text-xs font-semibold text-text-muted uppercase tracking-wider bg-surface-50 border-b border-surface-200 whitespace-nowrap hover:text-primary-600 transition-colors";
+  const thClass = "cursor-pointer select-none px-4 py-3 text-left text-xs font-semibold text-text-muted bg-surface-50 border-b border-surface-200 whitespace-nowrap hover:text-primary-600 transition-colors";
+  const sortLabels: Record<SortColumn, string> = {
+    viewCount: '再生数',
+    hypothesisCount: '仮説数',
+    likeCount: 'いいね数',
+    title: 'タイトル',
+    date: '日付',
+  };
 
   return (
     <>
-      <div className="w-full card-modern overflow-hidden">
+      {/* Mobile: sort controls */}
+      <div className="hidden max-md:flex w-full card-modern p-4 mb-4 items-center justify-center gap-2">
+        <label htmlFor="popular-sort" className="text-sm font-medium text-text-secondary">並び順:</label>
+        <select
+          id="popular-sort"
+          value={sortColumn}
+          onChange={(e) => setSortColumn(e.target.value as SortColumn)}
+          className="px-3 py-1.5 border border-surface-200 rounded-lg bg-surface-50 text-text-primary text-sm cursor-pointer focus:outline-none focus:border-primary-400"
+        >
+          {(Object.keys(sortLabels) as SortColumn[]).map(column => (
+            <option key={column} value={column}>{sortLabels[column]}</option>
+          ))}
+        </select>
+        <button
+          onClick={() => setSortDirection(prev => prev === 'asc' ? 'desc' : 'asc')}
+          className="btn-secondary text-xs px-3 py-1.5"
+          aria-label={sortDirection === 'asc' ? '昇順' : '降順'}
+        >
+          {sortDirection === 'asc' ? '昇順 ↑' : '降順 ↓'}
+        </button>
+      </div>
+
+      {/* Desktop: table view */}
+      <div className="w-full card-modern overflow-hidden max-md:hidden">
         <table className="w-full border-separate border-spacing-0">
           <thead>
             <tr>
               <th className={`${thClass} first:rounded-tl-2xl`} onClick={() => handleSort('title')}>
-                タイトル {sortColumn === 'title' && (sortDirection === 'asc' ? '\u2191' : '\u2193')}
+                タイトル {sortColumn === 'title' && (sortDirection === 'asc' ? '↑' : '↓')}
               </th>
               <th className={thClass} onClick={() => handleSort('viewCount')}>
-                再生 {sortColumn === 'viewCount' && (sortDirection === 'asc' ? '\u2191' : '\u2193')}
+                再生 {sortColumn === 'viewCount' && (sortDirection === 'asc' ? '↑' : '↓')}
               </th>
               <th className={thClass} onClick={() => handleSort('hypothesisCount')}>
-                仮説 {sortColumn === 'hypothesisCount' && (sortDirection === 'asc' ? '\u2191' : '\u2193')}
+                仮説 {sortColumn === 'hypothesisCount' && (sortDirection === 'asc' ? '↑' : '↓')}
               </th>
               <th className={thClass} onClick={() => handleSort('likeCount')}>
-                いいね {sortColumn === 'likeCount' && (sortDirection === 'asc' ? '\u2191' : '\u2193')}
+                いいね {sortColumn === 'likeCount' && (sortDirection === 'asc' ? '↑' : '↓')}
               </th>
               <th className={thClass} onClick={() => handleSort('date')}>
-                日付 {sortColumn === 'date' && (sortDirection === 'asc' ? '\u2191' : '\u2193')}
+                日付 {sortColumn === 'date' && (sortDirection === 'asc' ? '↑' : '↓')}
               </th>
-              <th className={`px-4 py-3 text-left text-xs font-semibold text-text-muted uppercase tracking-wider bg-surface-50 border-b border-surface-200 last:rounded-tr-2xl whitespace-nowrap`}>リンク</th>
+              <th className="px-4 py-3 text-left text-xs font-semibold text-text-muted bg-surface-50 border-b border-surface-200 last:rounded-tr-2xl whitespace-nowrap">リンク</th>
             </tr>
           </thead>
           <tbody>
@@ -130,19 +175,13 @@ export default function PopularBroadcastsContent({
                       </span>
                     </div>
                   </td>
-                  <td className="px-4 py-3 text-sm text-text-secondary border-b border-surface-100 whitespace-nowrap font-mono text-xs">{broadcast.viewCount.toLocaleString()}</td>
-                  <td className="px-4 py-3 text-sm text-text-secondary border-b border-surface-100 whitespace-nowrap font-mono text-xs">{broadcast.hypothesisCount}</td>
-                  <td className="px-4 py-3 text-sm text-text-secondary border-b border-surface-100 whitespace-nowrap font-mono text-xs">{broadcast.likeCount || ''}</td>
-                  <td className="px-4 py-3 text-sm text-text-secondary border-b border-surface-100 whitespace-nowrap">{broadcast.date || '\u2014'}</td>
+                  <td className="px-4 py-3 text-text-secondary border-b border-surface-100 whitespace-nowrap font-mono text-xs">{broadcast.viewCount.toLocaleString()}</td>
+                  <td className="px-4 py-3 text-text-secondary border-b border-surface-100 whitespace-nowrap font-mono text-xs">{broadcast.hypothesisCount}</td>
+                  <td className="px-4 py-3 text-text-secondary border-b border-surface-100 whitespace-nowrap font-mono text-xs">{broadcast.likeCount || ''}</td>
+                  <td className="px-4 py-3 text-sm text-text-secondary border-b border-surface-100 whitespace-nowrap">{broadcast.date || '—'}</td>
                   <td className="px-4 py-3 border-b border-surface-100 whitespace-nowrap">
                     <div className="flex items-center gap-1.5 opacity-70 group-hover:opacity-100 transition-opacity">
-                      <button type="button" onClick={() => toggleEmbedVisibility(broadcast.id)} className="btn-icon" aria-label={visibleEmbeds.has(broadcast.id) ? '非表示' : '再生'}>
-                        {visibleEmbeds.has(broadcast.id) ? '\u23F9\uFE0F' : '\u25B6\uFE0F'}
-                      </button>
-                      <button type="button" onClick={() => router.push(`/?tab=hypotheses&series=${encodeURIComponent(broadcast.series && broadcast.series.trim() ? broadcast.series.trim() : 'その他')}`)} className="btn-icon" aria-label="仮説を見る">
-                        💬
-                      </button>
-                      <SummaryButton broadcast={broadcast} onOpenSummary={openSummaryModal} />
+                      {renderActions(broadcast)}
                     </div>
                   </td>
                 </tr>
@@ -158,6 +197,44 @@ export default function PopularBroadcastsContent({
           </tbody>
         </table>
       </div>
+
+      {/* Mobile: card view */}
+      <div className="hidden max-md:flex w-full flex-col gap-3">
+        {sortedBroadcasts.map((broadcast) => (
+          <div key={broadcast.id} className="card-modern p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 flex-1">
+                <p className="m-0 text-sm font-medium text-text-primary leading-snug">{broadcast.title}</p>
+                <p className="m-0 mt-1 text-xs text-text-muted">
+                  {broadcast.series && broadcast.series.trim() ? broadcast.series.trim() : 'その他'}
+                  {broadcast.date && (
+                    <>
+                      <span className="mx-1.5">·</span>
+                      {broadcast.date}
+                    </>
+                  )}
+                </p>
+              </div>
+              <div className="flex items-center gap-1.5 flex-shrink-0">
+                {renderActions(broadcast)}
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center gap-1.5 mt-2.5">
+              <span className="text-xs text-text-secondary bg-surface-100 px-2 py-0.5 rounded-full">再生 {broadcast.viewCount.toLocaleString()}</span>
+              <span className="text-xs text-text-secondary bg-surface-100 px-2 py-0.5 rounded-full">仮説 {broadcast.hypothesisCount}</span>
+              {broadcast.likeCount ? (
+                <span className="text-xs text-text-secondary bg-surface-100 px-2 py-0.5 rounded-full">いいね {broadcast.likeCount}</span>
+              ) : null}
+            </div>
+            {visibleEmbeds.has(broadcast.id) && (
+              <div className="mt-3 pt-3 border-t border-surface-100">
+                <BroadcastEmbed broadcast={broadcast} embedType={embedType} height={152} />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
       <BroadcastSummaryModal
         broadcast={selectedBroadcastForSummary}
         isOpen={summaryModalOpen}

--- a/components/SearchContent.tsx
+++ b/components/SearchContent.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import BroadcastEmbed from './BroadcastEmbed';
+import { PlayIcon, StopIcon, LightbulbIcon, SearchIcon } from './icons';
 import { SearchResultBroadcast } from '../types/broadcast';
 import { NextRouter } from 'next/router';
 
@@ -48,10 +49,9 @@ const SearchContent = React.memo(({
       <div className="w-full max-w-2xl card-modern p-6 mb-8 max-md:p-4">
         <form onSubmit={handleSearch} className="flex gap-3 items-center max-md:flex-col max-md:gap-3">
           <div className="relative flex-1 max-md:w-full">
-            <svg className="absolute left-3 top-1/2 -translate-y-1/2 text-text-muted" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <circle cx="11" cy="11" r="8"/>
-              <path d="m21 21-4.3-4.3"/>
-            </svg>
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-text-muted pointer-events-none">
+              <SearchIcon size={18} />
+            </span>
             <input
               type="text"
               id="searchQuery"
@@ -103,8 +103,8 @@ const SearchContent = React.memo(({
                     {broadcast.excerpt}
                   </div>
                   <div className="flex justify-end gap-1.5">
-                    <button type="button" onClick={() => toggleEmbedVisibility(broadcast.id)} className="btn-icon" aria-label={visibleEmbeds.has(broadcast.id) ? '非表示' : '再生'}>
-                      {visibleEmbeds.has(broadcast.id) ? '\u23F9\uFE0F' : '\u25B6\uFE0F'}
+                    <button type="button" onClick={() => toggleEmbedVisibility(broadcast.id)} className="btn-icon" aria-label={visibleEmbeds.has(broadcast.id) ? '再生を閉じる' : '再生する'}>
+                      {visibleEmbeds.has(broadcast.id) ? <StopIcon /> : <PlayIcon />}
                     </button>
                     <button
                       onClick={() => {
@@ -116,7 +116,7 @@ const SearchContent = React.memo(({
                       className="btn-icon"
                       aria-label="仮説を見る"
                     >
-                      💬
+                      <LightbulbIcon />
                     </button>
                   </div>
                   {visibleEmbeds.has(broadcast.id) && (

--- a/components/SummaryButton.tsx
+++ b/components/SummaryButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FileTextIcon } from './icons';
 import { PastBroadcast, PopularBroadcast } from '../types/broadcast';
 
 interface SummaryButtonProps<T extends PastBroadcast | PopularBroadcast> {
@@ -21,7 +22,7 @@ const SummaryButton = <T extends PastBroadcast | PopularBroadcast>({
       className="btn-icon"
       aria-label="要約を見る"
     >
-      📋
+      <FileTextIcon />
     </button>
   );
 };

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -13,7 +13,7 @@ interface TabProps {
 export default function Tabs({ active, tabs, onTabChange }: TabProps): React.ReactNode {
   return (
     <nav className="flex items-center">
-      <div className="flex bg-surface-100 rounded-xl p-1 gap-0.5">
+      <div className="flex w-max bg-surface-100 rounded-xl p-1 gap-0.5">
         {tabs.map((tab) => (
           <button
             key={tab.id}
@@ -22,7 +22,7 @@ export default function Tabs({ active, tabs, onTabChange }: TabProps): React.Rea
                 ? 'bg-white text-primary-700 shadow-app-sm font-semibold'
                 : 'bg-transparent text-text-muted hover:text-text-primary'
               }
-              max-md:px-3 max-md:text-xs`}
+              max-md:px-3.5`}
             onClick={() => onTabChange(tab.id)}
           >
             {tab.label}

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+
+interface IconProps {
+  size?: number;
+  className?: string;
+}
+
+function iconAttrs(size: number, className?: string) {
+  return {
+    width: size,
+    height: size,
+    viewBox: '0 0 24 24',
+    fill: 'none' as const,
+    stroke: 'currentColor',
+    strokeWidth: 2,
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+    className,
+    'aria-hidden': true,
+  };
+}
+
+export function PlayIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg {...iconAttrs(size, className)}>
+      <polygon points="6 3 20 12 6 21 6 3" />
+    </svg>
+  );
+}
+
+export function StopIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg {...iconAttrs(size, className)}>
+      <rect x="5" y="5" width="14" height="14" rx="2" />
+    </svg>
+  );
+}
+
+export function LightbulbIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg {...iconAttrs(size, className)}>
+      <path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5" />
+      <path d="M9 18h6" />
+      <path d="M10 22h4" />
+    </svg>
+  );
+}
+
+export function FileTextIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg {...iconAttrs(size, className)}>
+      <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
+      <path d="M14 2v4a2 2 0 0 0 2 2h4" />
+      <path d="M16 13H8" />
+      <path d="M16 17H8" />
+    </svg>
+  );
+}
+
+export function ChevronRightIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg {...iconAttrs(size, className)}>
+      <path d="m9 18 6-6-6-6" />
+    </svg>
+  );
+}
+
+export function SearchIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg {...iconAttrs(size, className)}>
+      <circle cx="11" cy="11" r="8" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
+  );
+}
+
+export function MusicOffIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg {...iconAttrs(size, className)}>
+      <circle cx="8" cy="18" r="4" />
+      <path d="M12 18V2l7 4" />
+    </svg>
+  );
+}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,20 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html lang="ja">
+      <Head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;600;700&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -146,35 +146,43 @@ export default function Home() {
         <title>Podcast Library</title>
         <meta name="description" content="ポッドキャスト配信ライブラリ" />
         <link rel="icon" href="/favicon.ico" />
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
       </Head>
 
       <header className="glass-header sticky top-0 z-20">
-        <div className="max-w-7xl mx-auto px-6 py-3 flex items-center justify-between max-md:px-4 max-md:py-2">
-          <div className="flex items-center gap-3">
-            <div className="w-8 h-8 rounded-lg bg-hero-gradient flex items-center justify-center shadow-glow">
-              <span className="text-white text-sm font-bold">P</span>
+        <div className="max-w-7xl mx-auto px-6 py-3 max-md:px-4 max-md:py-2">
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <div className="w-8 h-8 rounded-lg bg-hero-gradient flex items-center justify-center shadow-glow">
+                <span className="text-white text-sm font-bold">P</span>
+              </div>
+              <h1 className="text-lg font-semibold text-text-primary m-0 max-md:text-base">Podcast Library</h1>
             </div>
-            <h1 className="text-lg font-semibold text-text-primary m-0 max-md:text-base">Podcast Library</h1>
+            <div className="flex items-center gap-2">
+              <div className="max-md:hidden">
+                <Tabs
+                  active={activeTab}
+                  tabs={tabs}
+                  onTabChange={handleTabChange}
+                />
+              </div>
+              <button
+                className="ml-2 p-2 rounded-xl text-text-muted hover:text-text-primary hover:bg-surface-100 transition-all duration-200 max-md:ml-0 max-md:p-1.5"
+                onClick={() => setIsSettingsOpen(true)}
+                aria-label="設定を開く"
+              >
+                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M10 13a3 3 0 100-6 3 3 0 000 6z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                  <path d="M16.5 10a1.5 1.5 0 00.9-2.7l-1-1.7a1.5 1.5 0 00-2.6 0l-.1.2a1.5 1.5 0 01-2.1.5 1.5 1.5 0 01-.7-1.3V4.5A1.5 1.5 0 009.5 3h-1A1.5 1.5 0 007 4.5v.2a1.5 1.5 0 01-.7 1.3 1.5 1.5 0 01-2.1-.5l-.1-.2a1.5 1.5 0 00-2.6 0l-1 1.7A1.5 1.5 0 001.5 10h.2a1.5 1.5 0 011.3.7 1.5 1.5 0 01-.5 2.1l-.2.1a1.5 1.5 0 00-.5 2.1l.5.8a1.5 1.5 0 002 .5l.2-.1a1.5 1.5 0 012.1.5 1.5 1.5 0 01.7 1.3v.2a1.5 1.5 0 001.5 1.5h1a1.5 1.5 0 001.5-1.5v-.2a1.5 1.5 0 01.7-1.3 1.5 1.5 0 012.1.5l.1.2a1.5 1.5 0 002.6 0l.5-.8a1.5 1.5 0 00-.5-2.1l-.2-.1a1.5 1.5 0 01-.5-2.1 1.5 1.5 0 011.3-.7h.2z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>
+              </button>
+            </div>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="hidden max-md:block mt-2 -mx-4 px-4 overflow-x-auto">
             <Tabs
               active={activeTab}
               tabs={tabs}
               onTabChange={handleTabChange}
             />
-            <button
-              className="ml-2 p-2 rounded-xl text-text-muted hover:text-text-primary hover:bg-surface-100 transition-all duration-200 max-md:p-1.5"
-              onClick={() => setIsSettingsOpen(true)}
-              aria-label="設定を開く"
-            >
-              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M10 13a3 3 0 100-6 3 3 0 000 6z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                <path d="M16.5 10a1.5 1.5 0 00.9-2.7l-1-1.7a1.5 1.5 0 00-2.6 0l-.1.2a1.5 1.5 0 01-2.1.5 1.5 1.5 0 01-.7-1.3V4.5A1.5 1.5 0 009.5 3h-1A1.5 1.5 0 007 4.5v.2a1.5 1.5 0 01-.7 1.3 1.5 1.5 0 01-2.1-.5l-.1-.2a1.5 1.5 0 00-2.6 0l-1 1.7A1.5 1.5 0 001.5 10h.2a1.5 1.5 0 011.3.7 1.5 1.5 0 01-.5 2.1l-.2.1a1.5 1.5 0 00-.5 2.1l.5.8a1.5 1.5 0 002 .5l.2-.1a1.5 1.5 0 012.1.5 1.5 1.5 0 01.7 1.3v.2a1.5 1.5 0 001.5 1.5h1a1.5 1.5 0 001.5-1.5v-.2a1.5 1.5 0 01.7-1.3 1.5 1.5 0 012.1.5l.1.2a1.5 1.5 0 002.6 0l.5-.8a1.5 1.5 0 00-.5-2.1l-.2-.1a1.5 1.5 0 01-.5-2.1 1.5 1.5 0 011.3-.7h.2z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-              </svg>
-            </button>
           </div>
         </div>
       </header>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -7,7 +7,7 @@
     padding: 0;
     margin: 0;
     line-height: 1.6;
-    font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    font-family: 'Inter', 'Noto Sans JP', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
       "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji",
       "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     background: linear-gradient(180deg, #f8fafc 0%, #eef2ff 40%, #f8fafc 100%);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,26 @@ module.exports = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: [
+          'Inter',
+          '"Noto Sans JP"',
+          'ui-sans-serif',
+          'system-ui',
+          '-apple-system',
+          'BlinkMacSystemFont',
+          '"Segoe UI"',
+          'Roboto',
+          '"Helvetica Neue"',
+          'Arial',
+          'sans-serif',
+          '"Apple Color Emoji"',
+          '"Segoe UI Emoji"',
+        ],
+      },
+      borderWidth: {
+        '3': '3px',
+      },
       colors: {
         primary: {
           50: '#eef2ff',


### PR DESCRIPTION
## 概要

既存のインディゴ基調のデザインを維持しつつ、全体を洗練させるブラッシュアップです。特にモバイルでの読みやすさ(容易なアクセス)を重視しています。

## 変更内容

### アイコン・タイポグラフィ
- SVGアイコンセット `components/icons.tsx` を新設し、OS依存の絵文字ボタン(▶️ ⏹️ 💬 📋)をすべて置き換え。仮説リンクは電球アイコンに変更
- `Noto Sans JP` を読み込み、日本語の表示フォントを統一(`pages/_document.tsx` を新設し `lang="ja"` も設定。フォント読み込みは `index.tsx` の `<Head>` から移動)
- 日本語見出しに効果のない `uppercase tracking-wider` を削除

### モバイル対応
- **配信一覧・人気の配信**: 小画面ではテーブルをカード表示に切り替え。テーブルヘッダーでのソートの代替として「並び順」セレクタ+昇順/降順ボタンを追加
- **ヘッダー**: 2段構成にし、タブを横スクロール可能に
- **仮説タブ**: 散布図の凡例を狭い画面ではグラフ下部に横並び表示(従来はグラフに重なっていた)。グラフ高さも 480px に調整

### 細部の修正
- 仮説のフィードバックボタンに「興味深い」「画期的」「検証したい」のテキストラベルを追加
- Tailwind に未定義だった `border-3` / `border-l-3` を定義(ローディングスピナーの枠線が効いていなかった不具合の修正)
- 埋め込み利用不可時のフォールバック表示をデザイントークン(surface/text)に統一
- 再生ボタンの aria-label を「再生する/再生を閉じる」に明確化

## 確認内容

- `pnpm type-check` / `pnpm lint` / `pnpm build` すべて通過
- 本番ビルドを起動し、Playwright でデスクトップ(1280px)・モバイル(390px)の全タブをスクリーンショットで目視確認(APIレスポンスはサンプルデータでモック)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1nyC9KL35XSvSRSqrhw9R

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1nyC9KL35XSvSRSqrhw9R)_